### PR TITLE
Add bitcoind v0.20.0 and lnd v0.11.0 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ This package is also used in production in
 
 Setup
 -----
-The binaries bitcoind, bitcoin-cli, lnd, and lncli are expected to be found in 
-`$PATH`.
+The binaries bitcoind (v0.20.0), bitcoin-cli, lnd (v0.11.0), and lncli are expected to be found in 
+`$PATH`, e.g., put these binaries into your ~/bin folder.
 
 You can use the tool in two different standalone modes:
 

--- a/lnregtest/lib/network_components.py
+++ b/lnregtest/lib/network_components.py
@@ -409,8 +409,8 @@ class RegTestLND(object):
         """Look for `regex` in the logs."""
 
         ex = re.compile(regex)
-        for l in self.logs:
-            if ex.search(l):
+        for log in self.logs:
+            if ex.search(log):
                 logging.debug("Found '%s' in logs", regex)
                 return True
 

--- a/lnregtest/lib/node_config_templates.py
+++ b/lnregtest/lib/node_config_templates.py
@@ -25,4 +25,5 @@ bitcoind_config_template = \
     "zmqpubrawtx=tcp://127.0.0.1:28333\n" \
     "regtest=1\n" \
     "rpcuser=lnd\n" \
-    "rpcpassword=123456"
+    "rpcpassword=123456\n" \
+    "fallbackfee=0.00001000\n"


### PR DESCRIPTION
Adds compatibility for bitcoind v0.20.0 and lnd v0.11.0.

The new version of bitcoind couldn't estimate fees using the `sendtoaddress` command. The suggested `fallbackfee` config setting is added to `bitcoin.conf` in order to remediate the problem.