### PR TITLE
network_components: fix deprecated notifyAll usage

### DIFF
--- a/lnregtest/lib/network_components.py
+++ b/lnregtest/lib/network_components.py
@@ -509,7 +509,7 @@ class LightningDaemon(ABC):
                     break
                 with self.logs_cond:
                     self.logs.append(str(line.rstrip()))
-                    self.logs_cond.notifyAll()
+                    self.logs_cond.notify_all()
         except ValueError:
             self.running = False
 


### PR DESCRIPTION
Fixes warning: `DeprecationWarning: notifyAll() is deprecated, use notify_all() instead`